### PR TITLE
Update to v4.61.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.59.0" %}
+{% set version = "4.61.1" %}
 
 package:
   name: tqdm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: d666ae29164da3e517fcf125e41d4fe96e5bb375cd87ff9763f6b38b5592fe33
+  sha256: 24be966933e942be5f074c29755a95b315c69a91f839a29139bf26ffffe2d3fd
 
 build:
   noarch: python
@@ -20,7 +20,9 @@ requirements:
     - python >=2.7
     - pip
     - setuptools_scm >=3.4
+    - setuptools >=42
     - toml
+    - wheel
   run:
     - python >=2.7
 
@@ -44,7 +46,7 @@ test:
 
 about:
   home: https://pypi.python.org/pypi/tqdm
-  license: MPL-2.0 or MIT
+  license: MPL-2.0 AND MIT
   license_family: MOZILLA
   license_file: LICENCE
   summary: A Fast, Extensible Progress Meter


### PR DESCRIPTION
Category:  miniconda | subcategory:   | pkg_type:  python
Popularity:  6537844 downloads -  tqdm  4.61.1  A Fast, Extensible Progress Meter  
Version change: bump version number from 4.59.0 to 4.61.1
  license: MPL-2.0 or MIT
Release date:  Jun 12, 2021, https://pypi.org/project/tqdm/#history
Bug Tracker: lot of new open issues https://github.com/tqdm/tqdm/issues
Changelog:  https://tqdm.github.io/releases/
Upsteam License: https://github.com/tqdm/tqdm/blob/master/LICENCE
Upstream setup.cfg:  https://github.com/tqdm/tqdm/blob/master/setup.cfg

The package tqdm is mentioned inside the packages:
conda-build | conda-package-handling | conda-standalone | conda-verify | coremltools | keras-ocr | neon | nltk | pandas-profiling | panel | pymc3 | pysal | segregation | spacy | tensorflow-datasets | tobler | twine | 

Actions:
1. Update dependencies
2. Add missing packages
3. Fix license

Result:
- all-succeeded