### PR TITLE
tqdm 4.63.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.62.3" %}
+{% set version = "4.63.0" %}
 
 package:
   name: tqdm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d
+  sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
 
 build:
   noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - tqdm = tqdm.cli:main
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python >=2.7
-    - colorama  # [win]
+    - colorama
 
 test:
   requires:
@@ -33,7 +33,6 @@ test:
     - pytest
     - pytest-timeout
     - pytest-asyncio  # [py>=37]
-    - python <3.10
   source_files:
     - tests
     - setup.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - pip
     - pytest
     - pytest-timeout
-    - pytest-asyncio  # [py>=37]
+    - pytest-asyncio
   source_files:
     - tests
     - setup.cfg


### PR DESCRIPTION
Update tqdm to 4.63.0

License: https://github.com/tqdm/tqdm/blob/v4.63.0/LICENCE
Requirements:
- https://github.com/tqdm/tqdm/blob/v4.63.0/pyproject.toml
- https://github.com/tqdm/tqdm/blob/v4.63.0/setup.cfg

Actions:
1. Reset build number to 0
2. Remove a selector for colorama in run as it's a noarch package
3. Remove selectors for pytest-asyncio in test/requires
4. Remove python <3.10 from test/requires