### PR TITLE
tqdm 4.64.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.63.0" %}
+{% set version = "4.64.0" %}
 
 package:
   name: tqdm
@@ -6,10 +6,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
+  sha256: 40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -24,15 +23,16 @@ requirements:
     - toml
     - wheel
   run:
-    - python >=2.7
-    - colorama
+    - python
+    - colorama  # [win]
+    - importlib_resources  # [py<37]
 
 test:
   requires:
     - pip
     - pytest
     - pytest-timeout
-    - pytest-asyncio
+    - pytest-asyncio  # [py>=37]
   source_files:
     - tests
     - setup.cfg


### PR DESCRIPTION
Update tqdm to 4.64.0

Changelog: https://tqdm.github.io/releases/
License: https://github.com/tqdm/tqdm/blob/v4.64.0/LICENCE
Requirements:
- https://github.com/tqdm/tqdm/blob/v4.64.0/pyproject.toml
- https://github.com/tqdm/tqdm/blob/v4.64.0/setup.cfg

Actions:
1. Remove `noarch: python`
2. Fix `python` in `run`
3. Update `run` dependencies:  update`colorama  # [win]`, add `importlib_resources  # [py<37]`
4. Update pinnings for `pytest-asyncio` in `test/requires`