### PR TITLE
Update 4.64.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - toml
     - wheel
   run:
-    - python
+    - python >=2.7
     - colorama
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.62.3" %}
+{% set version = "4.63.0" %}
 
 package:
   name: tqdm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d
+  sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.63.0" %}
+{% set version = "4.64.1" %}
 
 package:
   name: tqdm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: 1d9835ede8e394bb8c9dcbffbca02d717217113adc679236873eeaac5bc0b3cd
+  sha256: 5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   run:
     - python >=2.7
     - colorama
+    - importlib_resources # [py<37]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - toml
     - wheel
   run:
-    - python >=2.7
+    - python
     - colorama
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,18 +25,15 @@ requirements:
   run:
     - python >=2.7
     - colorama
-    - python
-    - colorama  # [win]
-    - importlib_resources  # [py<37]
 
 test:
   requires:
     - pip
     - pytest
     - pytest-timeout
-    - pytest-asyncio  # [py>=37]
+    - pytest-asyncio
   source_files:
-    # - tests
+    - tests
     - setup.cfg
     - pyproject.toml
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,13 +45,13 @@ test:
     - pytest -k "not tests_perf and not test_pipes" #[win]
     - pytest -k "not tests_perf" #[unix]
 about:
-  home: https://pypi.python.org/pypi/tqdm
+  home: https://tqdm.github.io/
   license: MPL-2.0 AND MIT
   license_family: MOZILLA
   license_file: LICENCE
   summary: A Fast, Extensible Progress Meter
   dev_url: https://github.com/tqdm/tqdm
-  doc_url: https://github.com/tqdm/tqdm#tqdm
+  doc_url: https://tqdm.github.io/
   doc_source_url: https://github.com/tqdm/tqdm/blob/master/README.rst
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
 
 build:
   noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - tqdm = tqdm.cli:main
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python >=2.7
-    - colorama  # [win]
+    - colorama
 
 test:
   requires:
@@ -33,7 +33,6 @@ test:
     - pytest
     - pytest-timeout
     - pytest-asyncio  # [py>=37]
-    - python <3.10
   source_files:
     - tests
     - setup.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - pip check
     - tqdm --help
     - tqdm -v
-    - pytest -k "not tests_perf"
-
+    - pytest -k "not tests_perf and not test_pipes" #[win]
+    - pytest -k "not tests_perf" #[unix]
 about:
   home: https://pypi.python.org/pypi/tqdm
   license: MPL-2.0 AND MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - toml
     - wheel
   run:
-    - python >=2.7
+    - python
     - colorama  # [win]
     - importlib_resources # [py<37]
 
@@ -43,7 +43,8 @@ test:
     - pip check
     - tqdm --help
     - tqdm -v
-    - pytest -k "not tests_perf and not test_pipes" #[win]
+    # win-64 does not support certain tests, so some are skipped.
+    - pytest -k "not tests_perf and not test_pipes and not test_as_completed" #[win]
     - pytest -k "not tests_perf" #[unix]
 about:
   home: https://tqdm.github.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - pip
     - pytest
     - pytest-timeout
-    - pytest-asyncio  # [py>=37]
+    - pytest-asyncio
   source_files:
     - tests
     - setup.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python >=2.7
-    - colorama
+    - colorama  # [win]
     - importlib_resources # [py<37]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   sha256: 5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -34,7 +33,7 @@ test:
     - pytest-timeout
     - pytest-asyncio
   source_files:
-    - tests
+    # - tests
     - setup.cfg
     - pyproject.toml
   imports:


### PR DESCRIPTION
# `tqdm` version bump to `4.64.1`
- updated sha256
- removed dependency pinnings
- edited tests to not run `test_pipes` and `test_as_completed` on Windows platforms