### PR TITLE
PKG-5552: Update tqdm dependency to 4.66.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.66.4" %}
+{% set version = "4.66.5" %}
 
 package:
   name: tqdm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tqdm/tqdm-{{ version }}.tar.gz
-  sha256: e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb
+  sha256: e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad
 
 build:
   number: 0


### PR DESCRIPTION
tqdm 4.66.5

**Destination channel:** defaults

### Links

- [PKG-5552](https://anaconda.atlassian.net/browse/PKG-5552) 
- [Upstream repository](https://github.com/tqdm/tqdm)
- [Upstream changelog/diff](https://github.com/tqdm/tqdm/releases)


### Explanation of changes:

- Update to latest minor release


[PKG-5552]: https://anaconda.atlassian.net/browse/PKG-5552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ